### PR TITLE
Adds support for sha1 and sha512 hashes

### DIFF
--- a/apt.go
+++ b/apt.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/md5"
+	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -138,7 +140,9 @@ func (a *AptMethod) ReadObejct(message map[string]string) {
 		body, _ := ioutil.ReadAll(resp.Body)
 		ioutil.WriteFile(filename, body, 0644)
 		md5sum := md5.Sum(body)
-		shasum := sha256.Sum256(body)
+		sha1sum := sha1.Sum(body)
+		sha256sum := sha256.Sum256(body)
+		sha512sum := sha512.Sum512(body)
 		a.SendUriDone(map[string]string{
 			"URI":           uri,
 			"Filename":      filename,
@@ -146,7 +150,9 @@ func (a *AptMethod) ReadObejct(message map[string]string) {
 			"Last-Modified": resp.Header.Get("last-modified"),
 			"MD5-Hash":      fmt.Sprintf("%x", md5sum),
 			"MD5Sum-Hash":   fmt.Sprintf("%x", md5sum),
-			"SHA256-Hash":   fmt.Sprintf("%x", shasum),
+			"SHA1-Hash":     fmt.Sprintf("%x", sha1sum),
+			"SHA256-Hash":   fmt.Sprintf("%x", sha256sum),
+			"SHA512-Hash":   fmt.Sprintf("%x", sha512sum),
 		})
 	} else {
 		a.SendUriFailure(map[string]string{


### PR DESCRIPTION
Hi there!

Thanks for apt-gcs, I've started using it recently with Aptly rsync'd to a GCS bucket and so far it has been great :) I did encounter a problem though where I was receiving digest failures on package installation attempts from the GCS bucket.  I manually verified that all digests matched so it was rather puzzling at first but eventually I came across [this blog post](https://www.lucidchart.com/techblog/2016/06/13/apt-transport-for-s3/) which determined that the poor documentation of the apt method interface fails to mention that you need to return all supported apt hashes:

```Although documentation mentions only MD5-Hash, if the method does not provide hashes for all algorithms in the package index, apt-get fails with “Failed to fetch … Hash Sum mismatch” (example). Include all standard algorithms: MD5-Hash, SHA1-Hash, SHA256-Hash, SHA512-Hash.```

After applying the changes in this pull request I was able to fetch packages from GCS without issue.  Hope this helps!