### PR TITLE
Return the error message on object get failure

### DIFF
--- a/apt.go
+++ b/apt.go
@@ -157,7 +157,7 @@ func (a *AptMethod) ReadObejct(message map[string]string) {
 	} else {
 		a.SendUriFailure(map[string]string{
 			"URI":        uri,
-			"Message":    "silly failure",
+			"Message":    err.Error(),
 			"FailReason": "really silly failure",
 		})
 	}


### PR DESCRIPTION
This change adds the error message to the `ReadObejct` response object, to assist in debugging.